### PR TITLE
Clarify Databricks learning path across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ End-to-end lakehouse demo on Databricks:
 
 ```
 /unity
-  00_uc_setup.sql              # Catalog + schemas + grants (one-time platform setup)
+  00_main_nyctaxi_catalogue_creator.ipynb  # Catalog + schemas + grants (one-time platform setup)
 /notebooks
-  01_auto_loader_bronze.sql    # OPTIONAL: Auto Loader into Bronze from files
+  01_auto_loader_bronze.sql.ipynb          # OPTIONAL: Auto Loader into Bronze from files
 /dlt
-  pipeline_settings.json       # DLT/Lakeflow pipeline config
-  02_dlt_pipeline.sql          # Bronze→Silver→Gold (streaming tables + EXPECT + MVs)
+  pipeline_settings.json                   # DLT/Lakeflow pipeline config
+  02_dlt_pipeline.sql.ipynb                # Bronze→Silver→Gold (streaming tables + EXPECT + MVs)
 /sql
-  03_gold_queries.sql          # Ad-hoc BI queries & helper views
+  03_gold_queries.sql                      # Ad-hoc BI queries & helper views
 /monitoring
-  mlflow_demo.py               # MLflow logging of simple pipeline metrics
-README.md                      # This document
+  mlflow_demo.py                           # MLflow logging of simple pipeline metrics
+README.md                                  # This document
 ```
 
 ### What each folder is for
@@ -36,13 +36,33 @@ README.md                      # This document
 * **/monitoring** — *Observability.* Small MLflow script to log basic counts/quality metrics after runs.
 * **README.md** — *Runbook & orientation.* How to operate the project end-to-end.
 
+### Recommended walkthrough order
+
+1. Start in **`/unity/README.md`** to learn the catalog, schema, and table structure you will target throughout the project.
+2. Move to **`/notebooks`** to configure and run ingestion once the governance layer exists.
+3. Review **`/monitoring`** so you know how to track metrics and health before scaling the pipeline.
+4. Dive into **`/dlt`** to understand how transformations and quality rules build on the earlier steps.
+5. Finish in **`/sql`** to see how analysts consume the Gold layer once the engineering pieces are in place.
+
+### Databricks concepts you will practice
+
+* **Workspace organization:** Import this repo into Databricks Repos so notebooks, SQL files, and scripts stay versioned together.
+* **Unity Catalog governance:** Build catalogs, schemas, tables, and permissions that isolate domains and enable fine-grained acc
+  ess.
+* **Incremental ingestion with Auto Loader:** Configure schema inference, checkpoints, and volumes/external locations.
+* **Delta Live Tables orchestration:** Author declarative pipelines with `LIVE TABLE` statements, expectations, and gold materia
+  lized views.
+* **Serverless SQL consumption:** Query Delta tables, publish dashboards, and materialize BI datasets with managed compute.
+* **Observability & MLflow:** Capture operational metrics, build health dashboards, and reason about data quality impacts.
+* **Workflows & Jobs:** Chain ingestion, DLT, and monitoring assets into an automated schedule to mimic production operations.
+
 ---
 
 ## Execution surfaces (who runs what)
 
 * **SQL Warehouse:** `/unity/*.sql`, `/sql/*.sql`
-* **Interactive Cluster or Job:** `/notebooks/01_auto_loader_bronze.sql` (if you use file ingest)
-* **DLT/Lakeflow Pipeline:** `/dlt/02_dlt_pipeline.sql` with `/dlt/pipeline_settings.json`
+* **Interactive Cluster or Job:** `/notebooks/01_auto_loader_bronze.sql.ipynb` (if you use file ingest)
+* **DLT/Lakeflow Pipeline:** `/dlt/02_dlt_pipeline.sql.ipynb` with `/dlt/pipeline_settings.json`
 * **Job/Notebook:** `/monitoring/mlflow_demo.py`
 
 ---
@@ -50,19 +70,20 @@ README.md                      # This document
 ## Quick start (minimal happy path)
 
 1. **Create catalog & schemas**
-   Open a **SQL Warehouse** and run: `/unity/00_uc_setup.sql`.
+   Open a **SQL Warehouse** and run: `/unity/00_main_nyctaxi_catalogue_creator.ipynb` (or import it as a SQL notebook and execu
+   te all cells).
 
 2. **Choose ONE Bronze source**
 
    * **Option A — Samples (lowest friction):**
-     *Skip* `/notebooks/01_auto_loader_bronze.sql`. In `/dlt/02_dlt_pipeline.sql`, use the `STREAM(samples.nyctaxi.trips)` variant for `raw.taxi_bronze`.
+     *Skip* `/notebooks/01_auto_loader_bronze.sql.ipynb`. In `/dlt/02_dlt_pipeline.sql.ipynb`, use the `STREAM(samples.nyctaxi.trips)` variant for `raw.taxi_bronze`.
    * **Option B — Auto Loader from files:**
-     Edit and run `/notebooks/01_auto_loader_bronze.sql` to point `cloud_files(...)` at your input location (DBFS mount/S3/ADLS). This creates `main_nyctaxi.raw.taxi_raw`. The DLT Bronze step then reads from that.
+     Edit and run `/notebooks/01_auto_loader_bronze.sql.ipynb` to point `cloud_files(...)` at your input location (DBFS mount/S3/ADLS). This creates `main_nyctaxi.raw.taxi_raw`. The DLT Bronze step then reads from that.
 
 3. **Create & run the pipeline**
 
    * In **Workflows → Pipelines**, create a pipeline.
-   * Use `/dlt/02_dlt_pipeline.sql` as the notebook/script.
+   * Use `/dlt/02_dlt_pipeline.sql.ipynb` as the notebook/script (export to `.sql` if you prefer a script file).
    * Set **Target** = `main_nyctaxi`.
    * Paste or attach `/dlt/pipeline_settings.json` (update the `"libraries"[0].notebook.path"` to your Repos path).
    * Use **Serverless** (Pro/Serverless required for Gold materialized views).
@@ -107,16 +128,16 @@ Files (S3/ADLS/DBFS) --(Auto Loader)--> raw.taxi_raw (Bronze, Delta)   [OPTIONAL
 
 ## File responsibilities (at a glance)
 
-* **/unity/00\_uc\_setup.sql**
+* **/unity/00\_main\_nyctaxi\_catalogue\_creator.ipynb**
   Creates `main_nyctaxi` and `raw/ref/mart` with basic grants. Run once per workspace or when reprovisioning.
 
-* **/notebooks/01\_auto\_loader\_bronze.sql** *(optional)*
+* **/notebooks/01\_auto\_loader\_bronze.sql.ipynb** *(optional)*
   Uses `cloud_files(...)` to incrementally ingest files to `main_nyctaxi.raw.taxi_raw` (Bronze). Edit the input path before running.
 
 * **/dlt/pipeline\_settings.json**
   Pipeline configuration (edition, channel, serverless, storage, target). Update the `"libraries".[0].notebook.path"` to your actual Repos path.
 
-* **/dlt/02\_dlt\_pipeline.sql**
+* **/dlt/02\_dlt\_pipeline.sql.ipynb**
   Declares **STREAMING TABLES** for Bronze/Silver, applies `EXPECT` rules, and defines **Gold** `mart.daily_kpis` as a **materialized view**.
 
 * **/sql/03\_gold\_queries.sql**
@@ -133,7 +154,7 @@ Files (S3/ADLS/DBFS) --(Auto Loader)--> raw.taxi_raw (Bronze, Delta)   [OPTIONAL
 
   * Spark/DBUtils: `/Volumes/main_nyctaxi/raw/nyctaxi_landing/...`
   * Databricks CLI: `dbfs:/Volumes/main_nyctaxi/raw/nyctaxi_landing/...`
-* **If using `cloud_files(...)`** with a DBFS mount or external storage, update the path in `/notebooks/01_auto_loader_bronze.sql` accordingly.
+* **If using `cloud_files(...)`** with a DBFS mount or external storage, update the path in `/notebooks/01_auto_loader_bronze.sql.ipynb` accordingly.
 
 ---
 
@@ -184,7 +205,8 @@ Run `/monitoring/mlflow_demo.py` after a pipeline run to log:
 
 * **“Both paths provided are local” when copying files:** ensure the destination starts with `dbfs:/...`.
 * **Materialized view not supported:** use a **Pro/Serverless** SQL warehouse (or run the MV inside the pipeline). Otherwise, convert the Gold object to a standard table/view.
-* **Permission errors (create/read):** re-run `/unity/00_uc_setup.sql` and verify grants to your principal (e.g., `account users`).
+* **Permission errors (create/read):** re-run `/unity/00_main_nyctaxi_catalogue_creator.ipynb` and verify grants to your princip
+  al (e.g., `account users`).
 * **No Bronze data:** confirm you picked exactly one Bronze source (Samples *or* Auto Loader) and that the chosen path/table exists.
 
 ---
@@ -205,6 +227,16 @@ Run `/monitoring/mlflow_demo.py` after a pipeline run to log:
 * **Unity Catalog:** Governance layer (catalogs, schemas, tables, volumes, permissions).
 * **Serverless SQL Warehouse:** Managed compute for low-latency SQL, supports materialized views.
 * **MLflow:** Tracking runs/metrics for models or pipelines.
+
+---
+
+## Extend your Databricks learning
+
+* Explore **Lakehouse Monitoring** for automated anomaly detection and SLA tracking on Delta tables.
+* Experiment with **Delta Sharing** to publish the Gold dataset to external consumers or partner accounts.
+* Add a **Feature Engineering** step (e.g., with the Databricks Feature Store) if you want to turn the Silver layer into ML-ready features.
+* Integrate **Unity Catalog Access Control Lists** with SCIM-provisioned groups to mirror enterprise governance models.
+* Use **dbt, Delta Live Tables SQL Warehousing, or Spark Structured Streaming** notebooks to compare declarative vs. code-first transformation styles.
 
 ---
 

--- a/dlt/README.md
+++ b/dlt/README.md
@@ -1,0 +1,34 @@
+# Delta Live Tables Pipeline Guide
+
+The assets in this directory define the streaming transformation layer that turns Bronze ingestion into curated Silver and Gold datasets. Use them to configure a Delta Live Tables (DLT) pipeline or Lakeflow project that automates quality checks, incremental processing, and downstream serving tables for the NYC Taxi demo.
+
+## Files in this folder
+
+### `02_dlt_pipeline.sql.ipynb`
+* **Purpose:** Implements the DLT pipeline logic using SQL expectations and table definitions for the `raw`, `ref`, and `mart` schemas.
+* **What it builds:**
+  * Bronze streaming table sourced from the ingestion notebook output.
+  * Silver table (`trips_valid`) with data quality rules applied.
+  * Gold materialized view(s) that aggregate daily KPIs for analytics consumers.
+* **How to run it:** Attach the notebook to a DLT pipeline (Workflows → Pipelines) or Lakeflow project, choose a cluster policy/serverless mode, and point the storage location to your workspace path. If you prefer a pure SQL script, open the notebook in the Databricks UI and export it as a `.sql` file before referencing it in Jobs/Workflows.
+
+### `pipeline_settings.json`
+* **Purpose:** Provides a template for the pipeline configuration, including continuous mode, target catalog, storage, and libraries.
+* **How to use it:** Copy the JSON when creating the pipeline, updating the `library` path to match your repo workspace location (replace the `.sql` suffix with `.sql.ipynb` if you keep the notebook format) and customizing the storage/base paths for your environment.
+
+### Databricks concepts reinforced here
+
+* **Delta Live Tables expectations** for declarative data quality and SLA reporting.
+* **Streaming and materialized views** to power near-real-time BI workloads.
+* **Managed orchestration** via Workflows → Pipelines (or Lakeflow) with auto-scaling compute.
+* **Change data capture** patterns when you enable CDC, schema evolution, or advanced settings in `pipeline_settings.json`.
+
+## Where DLT fits in the overall flow
+
+1. **Unity Catalog foundation:** Run `/unity/00_main_nyctaxi_catalogue_creator.ipynb` to create the catalog and schemas that the pipeline references.
+2. **Feed Bronze data:** Execute `/notebooks/01_auto_loader_bronze.sql.ipynb` (or enable the sample ingestion) so the Bronze Delta table exists.
+3. **Deploy the pipeline:** Create or update the DLT pipeline using the SQL notebook and settings here, ensuring the target is `main_nyctaxi` (or your chosen catalog).
+4. **Serve downstream consumers:** The Gold outputs power the SQL queries in `/sql` and any dashboards or BI tools you layer on top.
+5. **Monitor and iterate:** After each run, use `/monitoring/mlflow_demo.py` or Lakehouse Monitoring to confirm row counts, data quality, and refresh cadences.
+
+With these DLT assets, you operationalize the transformation layer of the Lakehouse, enforcing quality expectations and delivering trusted data products for analytics and reporting.

--- a/dlt/pipeline_settings.json
+++ b/dlt/pipeline_settings.json
@@ -5,7 +5,7 @@
   "edition": "PRO",
   "channel": "CURRENT",
   "libraries": [
-    { "notebook": { "path": "/Repos/<your-user-or-path>/dlt/02_dlt_pipeline.sql" } }
+    { "notebook": { "path": "/Repos/<your-user-or-path>/dlt/02_dlt_pipeline.sql.ipynb" } }
   ],
   "target": "main_nyctaxi",
   "storage": "dbfs:/pipelines/nyctaxi",

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,37 @@
+# Monitoring and Observability Guide
+
+This directory contains lightweight observability assets that help you track the health of the NYC Taxi Lakehouse demo after the Delta Live Tables pipeline runs. Use the resources here to instrument key metrics and keep stakeholders informed about pipeline performance.
+
+## Files in this folder
+
+### `mlflow_demo.py`
+* **Purpose:** Logs basic operational metrics about the Silver layer to MLflow so you can trend row counts and contextual data over time.
+* **When to run it:** Trigger the script after successful DLT refreshes—either manually from a Databricks job or as a downstream task in a workflow.
+* **Prerequisites to configure:**
+  * Set the MLflow experiment path to a workspace location your team can access.
+  * Ensure the script references the same catalog and schema names created during Unity setup (defaults assume `main_nyctaxi.ref`).
+  * Provide the correct Delta table names or extend the script to pull additional metrics relevant to your governance policies.
+
+### Databricks concepts reinforced here
+
+* **MLflow tracking** for non-ML workloads (data pipelines, data quality metrics).
+* **Unity Catalog integration** by writing metrics to governed experiments and Delta tables.
+* **Jobs orchestration** by chaining monitoring tasks after DLT completes.
+* **Cross-team observability** when you publish the metrics into dashboards or alerting systems.
+
+### Extending observability for production
+
+* **Event logs:** Query the DLT pipeline event log to capture expectation pass/fail counts or schema evolution warnings.
+* **Lakehouse Monitoring:** Pair this script with native monitoring dashboards to visualize refresh latency and anomaly scores.
+* **Alerting:** Configure Databricks Jobs notifications or external alerting (PagerDuty, Teams, Slack) when metrics deviate from thresholds you define in MLflow.
+* **Data quality integration:** Persist the MLflow metrics back into a governed Delta table to join with product usage analytics or SLA dashboards.
+
+## How monitoring fits the overall flow
+
+1. **Unity Catalog first:** Run `/unity/00_main_nyctaxi_catalogue_creator.ipynb` so the catalog and schemas exist—MLflow runs will reference these governed table names.
+2. **Ingest Bronze data:** Use `/notebooks/01_auto_loader_bronze.sql.ipynb` (or the sample stream) to populate the Bronze table that the DLT pipeline consumes.
+3. **Build Silver/Gold with DLT:** Execute `/dlt/02_dlt_pipeline.sql.ipynb` (via a DLT pipeline) to materialize curated datasets that monitoring will observe.
+4. **Log metrics with MLflow:** Run `mlflow_demo.py` to capture row counts, pipeline metadata, or event log statistics after each refresh. These runs give you visibility into data quality and pipeline stability.
+5. **Iterate:** Expand the script with additional metrics, alerts, or integrations with Databricks Lakehouse Monitoring as your project matures.
+
+By operationalizing monitoring through MLflow (or your chosen observability tooling), you close the loop on the Lakehouse lifecycle—governed ingestion, reliable transformations, and measurable outcomes.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,34 @@
+# Ingestion Notebooks Guide
+
+This directory holds the interactive notebooks that seed the Bronze layer of the NYC Taxi Lakehouse demo. They are designed to be run after the Unity Catalog objects exist so that every Delta table lands in the governed `main_nyctaxi` catalog.
+
+## Notebooks in this folder
+
+### `01_auto_loader_bronze.sql.ipynb`
+* **Purpose:** Streams raw NYC Taxi trip files into the Bronze Delta table that the Delta Live Tables pipeline consumes.
+* **When to use it:** Choose this path when you want to demonstrate Auto Loader’s incremental ingestion from cloud object storage. The notebook can run on an interactive or job cluster with a DBR that supports Auto Loader (11.3+ recommended).
+* **Inputs to configure:**
+  * `source_url` (cloud storage path or volume) pointing at the raw taxi files.
+  * `checkpoint_location` unique to your workspace so Auto Loader can track progress.
+  * Target catalog/schema names that match the Unity setup (defaults use `main_nyctaxi.raw`).
+
+### Databricks concepts reinforced here
+
+* **Auto Loader** for incrementally streaming new files with schema inference and evolution.
+* **Volumes and external locations** for governed access to object storage.
+* **Streaming tables** that persist state so DLT can subscribe without additional orchestration.
+* **Job scheduling** when you wire the notebook into Workflows alongside the pipeline and monitoring steps.
+
+## How these notebooks fit the overall flow
+
+1. **After Unity setup:** Run the notebook once Unity Catalog has the `main_nyctaxi` catalog and the `raw` schema. This guarantees writes succeed and respect governance controls.
+2. **Before DLT:** Successful Bronze ingestion provides the source table that `/dlt/02_dlt_pipeline.sql.ipynb` expects for building Silver and Gold layers.
+3. **Re-running:** Because Auto Loader is incremental, subsequent runs pick up only new files. Resetting requires clearing the checkpoint and table manually—useful for demos that need a clean slate.
+
+## Operational tips
+
+* Use a cluster with the same access mode (single user or shared) as your production setup to mirror permissions.
+* When ingesting from external storage, make sure the Unity Catalog external locations referenced in the Unity README are created so Auto Loader can read the files.
+* Monitor the notebook run from the Jobs UI if you schedule it; long-running streams can continue appending data for real-time demos.
+
+By working through these notebooks, you establish the Bronze ingestion layer that powers the downstream Delta Live Tables transformations, SQL queries, and monitoring workflows in the rest of the repository.

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,0 +1,21 @@
+# SQL Consumption Guide
+
+The SQL assets in this directory show how to consume the curated Gold layer that the Delta Live Tables pipeline produces. Run them from a Databricks SQL Warehouse (Serverless recommended) after the Unity Catalog and pipeline steps finish.
+
+## Files in this folder
+
+### `03_gold_queries.sql`
+* **Purpose:** Provides a starting set of BI queries (KPI rollups, top trips, data validation) that analysts can run or turn into dashboard tiles.
+* **How to use it:**
+  * Open the file in Databricks SQL or the notebook editor and execute each statement against the `main_nyctaxi` catalog.
+  * Swap `main_nyctaxi` with the catalog/schema names you created in `/unity` if you rebranded the deployment.
+  * Use the query snippets as building blocks for dashboards, alerts, or data sharing products.
+
+## How SQL consumption fits the project
+
+1. **Governance first:** Ensure `/unity/00_main_nyctaxi_catalogue_creator.ipynb` has provisioned the catalog and schemas.
+2. **Ingest and transform:** Run the Auto Loader notebook (optional) and the DLT pipeline (`/dlt/02_dlt_pipeline.sql.ipynb`) to populate the Gold materialized views.
+3. **Query and visualize:** Use this SQL file to explore `mart.daily_kpis`, create visualizations, and share insights.
+4. **Iterate:** Extend the queries with additional aggregations, joins to external reference data, or data sharing (Delta Sharing) endpoints to round out your Databricks analytics story.
+
+By practicing with these SQL assets you complete the Lakehouse loop—governed data ingestion, reliable transformations, observability, and analytical consumption.


### PR DESCRIPTION
## Summary
- align repository instructions with the actual notebook filenames and add a SQL folder README for BI consumers
- expand the main README with a Databricks concept checklist and advanced learning suggestions
- enrich Unity, notebooks, DLT, and monitoring guides with concept overviews and concrete step-by-step references

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e5d556faac8320a7851215769a1172